### PR TITLE
Update Matomo Java Tracker to 3.0.2

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -337,8 +337,14 @@
 
         <dependency>
             <groupId>org.piwik.java.tracking</groupId>
-            <artifactId>matomo-java-tracker</artifactId>
-            <version>2.0</version>
+            <artifactId>matomo-java-tracker-java11</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.piwik.java.tracking</groupId>
+            <artifactId>matomo-java-tracker-servlet-javax</artifactId>
+            <version>3.0.2</version>
         </dependency>
 
         <dependency>

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoBitstreamTracker.java
@@ -27,6 +27,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.matomo.java.tracking.CustomVariable;
 import org.matomo.java.tracking.MatomoException;
 import org.matomo.java.tracking.MatomoRequest;
+import org.matomo.java.tracking.parameters.CustomVariables;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -79,7 +80,9 @@ public class ClarinMatomoBitstreamTracker extends ClarinMatomoTracker {
             matomoRequest.setActionUrl(itemIdentifier);
         }
         try {
-            matomoRequest.setPageCustomVariable(new CustomVariable("source", "bitstream"), 1);
+            // Deprecated. Try to configure the dimension "source" in Matomo and use
+            // matomoRequest.setDimensions(Map.of(1L, "bitstream"));
+            matomoRequest.setPageCustomVariables(new CustomVariables().add(new CustomVariable("source", "bitstream"), 1));
         } catch (MatomoException e) {
             log.error(e);
         }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoOAITracker.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/clarin/ClarinMatomoOAITracker.java
@@ -18,6 +18,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.matomo.java.tracking.CustomVariable;
 import org.matomo.java.tracking.MatomoException;
 import org.matomo.java.tracking.MatomoRequest;
+import org.matomo.java.tracking.parameters.CustomVariables;
 
 /**
  * Customized implementation of the ClarinMatomoTracker for the tracking the OAI harvesting events
@@ -55,7 +56,9 @@ public class ClarinMatomoOAITracker extends ClarinMatomoTracker {
         matomoRequest.setSiteId(siteId);
         log.debug("Logging to site " + matomoRequest.getSiteId());
         try {
-            matomoRequest.setPageCustomVariable(new CustomVariable("source", "oai"), 1);
+            // Deprecated. Try to configure the dimension "source" in Matomo and use
+            // matomoRequest.setDimensions(Map.of(1L, "oai"));
+            matomoRequest.setPageCustomVariables(new CustomVariables().add(new CustomVariable("source", "oai"), 1));
         } catch (MatomoException e) {
             log.error(e);
         }


### PR DESCRIPTION
### Hey @thanvanlong,

Just wanted to give your project a little boost with the latest and greatest from Matomo Java Tracker! 🚀

### Changes in a Nutshell:

- **Bug Fixes & Performance Boosts:** Say goodbye to some pesky bugs and enjoy a faster, smoother tracking experience.

- **Security Makeover:** We're getting the latest security swag to keep our project locked down.

- **Stay Cool with Compatibility:** Now we're best buddies with Matomo versions up to 5, so no more awkward compatibility issues.

- **Less Baggage:** Matomo Java Tracker 3.0.2 is lean and mean with fewer dependencies. Less stuff, more speed!

- **New Toys:** Check out the cool new dimension parameter for super-customizable tracking.

- **Java 11 Party:** We're upgrading to the latest Java 11 implementation. It's like giving our project a cool new set of wheels.

- **Smooth Moves:** If you're coming from version 2, no worries! There's a handy migration guide [here](https://github.com/matomo-org/matomo-java-tracker#migration-from-version-2-to-302) to make the switch painless.

### How to Test:

1. Update to Matomo Java Tracker version 3.0.2.
2. Make sure our project still builds like a champ.
3. Double-check that our Matomo tracking mojo is still on point.
4. Test out any new features and give that dimension parameter a spin.

### Where to Get Help:

- Dive into the [Javadoc](https://javadoc.io/doc/org.piwik.java.tracking/matomo-java-tracker-core/3.0.2/index.html) for the nitty-gritty details.
- Got issues or bright ideas? Hit up the [Matomo Java Tracker GitHub](https://github.com/matomo-org/matomo-java-tracker).

### Your Feedback Matters:

Give it a whirl and let us know how it goes! Your feedback is like gold to us. 🌟

Cheers,
Daniel
